### PR TITLE
Freepass bid adaptor: add publisher id to bid param

### DIFF
--- a/modules/freepassBidAdapter.js
+++ b/modules/freepassBidAdapter.js
@@ -72,6 +72,12 @@ export const spec = {
     data.user = prepareUserInfo(data.user, freepassId);
     data.device = prepareDeviceInfo(data.device, freepassId);
 
+    data.imp.forEach((imp, index) => {
+      if (validBidRequests[index] && validBidRequests[index].publisherId) {
+        imp.publisherId = validBidRequests[index].publisherId;
+      }
+    });
+
     data.test = validBidRequests[0].test || 0;
 
     logMessage('FreePass BidAdapter augmented ORTB bid request user: ', data.user);

--- a/modules/freepassBidAdapter.js
+++ b/modules/freepassBidAdapter.js
@@ -68,7 +68,7 @@ export const spec = {
     logMessage('FreePass BidAdapter interpreted ORTB bid request as ', data);
 
     // Only freepassId is supported
-    let freepassId = (validBidRequests[0].userId && validBidRequests[0].userId.freepassId) || {};
+    const freepassId = (validBidRequests[0].userId && validBidRequests[0].userId.freepassId) || {};
     data.user = prepareUserInfo(data.user, freepassId);
     data.device = prepareDeviceInfo(data.device, freepassId);
 

--- a/test/spec/modules/freepassBidAdapter_spec.js
+++ b/test/spec/modules/freepassBidAdapter_spec.js
@@ -43,7 +43,8 @@ describe('FreePass adapter', function () {
             'userId': '56c4c789-71ce-46f5-989e-9e543f3d5f96',
             'commonId': 'commonIdValue'
           }
-        }
+        },
+        "publisherId" : "publisherIdValue"
       }];
       bidderRequest = {};
     });
@@ -107,6 +108,12 @@ describe('FreePass adapter', function () {
       expect(ortbData.device.ip).to.be.undefined;
       expect(ortbData.device.ext).to.be.an('object');
       expect(ortbData.device.ext.is_accurate_ip).to.equal(0);
+    });
+
+    it('should add publisherId when avilable', function () {
+      const bidRequest = spec.buildRequests(bidRequests, bidderRequest);
+      const ortbData = bidRequest.data;
+      expect(ortbData.imp[0].publisherId).to.equal('publisherIdValue');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
